### PR TITLE
Fix refresh token. expires_in has date format, not integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .idea
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/dcblogdev/laravel-dropbox",
     "keywords": ["Laravel", "Dropbox"],
     "require": {
-        "illuminate/support": "^5.5|^5.6|^5.7|^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0",
         "guzzlehttp/guzzle": "^6|^7"
     },
     "autoload": {

--- a/src/Dropbox.php
+++ b/src/Dropbox.php
@@ -2,6 +2,7 @@
 
 namespace Dcblogdev\Dropbox;
 
+use Carbon\Carbon;
 use Dcblogdev\Dropbox\Facades\Dropbox as Api;
 use Dcblogdev\Dropbox\Models\DropboxToken;
 use Dcblogdev\Dropbox\Resources\Files;
@@ -171,8 +172,7 @@ class Dropbox
         if (isset($token->refresh_token)) {
             // Check if token is expired
             // Get current time + 5 minutes (to allow for time differences)
-            $now = time() + 300;
-            if ($token->expires_in <= $now) {
+            if ($token->expires_in->lessThan(Carbon::now()->addMinutes(5))) {
                 // Token is expired (or very close to it) so let's refresh
                 $params = [
                     'grant_type'    => 'refresh_token',

--- a/src/Models/DropboxToken.php
+++ b/src/Models/DropboxToken.php
@@ -7,4 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 class DropboxToken extends Model
 {
     protected $guarded = [];
+
+    protected $casts = [
+        'expires_in' => 'datetime',
+    ];
 }


### PR DESCRIPTION
`now()+300` returns integer value. And this value can't be compared with  string datetime expires_in saved in database (see migration file). So app never uses a refresh token. 

Also, reduced supported versions to allow automatically do casts in model.