### PR TITLE
Fix token expiration check

### DIFF
--- a/src/Dropbox.php
+++ b/src/Dropbox.php
@@ -172,7 +172,7 @@ class Dropbox
             // Check if token is expired
             // Get current time + 5 minutes (to allow for time differences)
             $now = time() + 300;
-            if ($token->expires_in <= $now) {
+            if (strtotime($token->expires_in) <= $now) {
                 // Token is expired (or very close to it) so let's refresh
                 $params = [
                     'grant_type'    => 'refresh_token',


### PR DESCRIPTION
The token expiration check always returned false because the expiration date was not convert to time